### PR TITLE
v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ id
 5        arrived    2  15332    3  176661
 ```
 
-or follow [Evert's (2008: Figure 8)](https://www.stefan-evert.de/PUB/Evert2007HSK_extended_manuscript.pdf) notation of frequency signatures:
+or follow [Evert's (2008: Figure 8)](https://www.stephanie-evert.de/PUB/Evert2007HSK_extended_manuscript.pdf) notation of frequency signatures:
 
 ```python3
 >>> df.head()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 [![Build Status](https://github.com/fau-klue/pandas-association-measures/actions/workflows/python-build.yml/badge.svg)](https://github.com/fau-klue/pandas-association-measures/actions/workflows/python-build.yml)
-[![Coverage Status](https://coveralls.io/repos/github/fau-klue/pandas-association-measures/badge.svg?branch=master)](https://coveralls.io/github/fau-klue/pandas-association-measures?branch=master)
+[![PyPI version](https://badge.fury.io/py/association-measures.svg)](https://badge.fury.io/py/association-measures)
+[![License](https://img.shields.io/pypi/l/association-measures.svg)](https://github.com/fau-klue/association-measures/blob/master/LICENSE)
+[![Imports: pandas](https://img.shields.io/badge/%20imports-pandas-%231674b1?style=flat&labelColor=gray)](https://pandas.pydata.org/)
+<!-- [![Coverage Status](https://coveralls.io/repos/github/fau-klue/pandas-association-measures/badge.svg?branch=master)](https://coveralls.io/github/fau-klue/pandas-association-measures?branch=master) -->
 
 # Statistical Association Measures for Python pandas
 
@@ -9,29 +12,31 @@ http://www.collocations.de/AM/index.html
 
 # Installation
 
-**Prerequisites:**
+##### Dependencies
 - [pandas](https://pandas.pydata.org/)
-- [scipy](https://scipy.org/) (as of version v0.1.7)
+- [scipy](https://scipy.org/)
 
-**Installation using pip:**
+##### Installation using pip
 
-    pip install association-measures
+    python3 -m pip install association-measures
 
-**Installation from source (requires Cython):**
+##### Installation from source (requires Cython)
 
     # Compile Cython code
-    python setup.py build_ext --inplace
+    python3 setup.py build_ext --inplace
 
     # Cython already compiled
-    python setup.py install
+    python3 setup.py install
 
 # Usage
 
 ## Input
-The module expects a pandas dataframe with reasonably named columns. Columns should either comprise the observed frequencies in a contingency table:
 
+The module expects a pandas dataframe with reasonably named columns; i.e. the columns must follow one of the following notations:
+
+- contingency table:
 ```python3
->>> df.head()
+>>> df
             item  O11    O12  O21     O22
 id
 1    appreciated    1  15333    1  176663
@@ -41,33 +46,38 @@ id
 5        arrived    2  15332    3  176661
 ```
 
-or follow [Evert's (2008: Figure 8)](https://www.stephanie-evert.de/PUB/Evert2007HSK_extended_manuscript.pdf) notation of frequency signatures:
-
-```python3
->>> df.head()
+- frequency signature (see [Evert 2008: Figure 8](https://www.stephanie-evert.de/PUB/Evert2007HSK_extended_manuscript.pdf)):
+  ```python3
+  >>> df
             item  f     f1   f2       N
-id
-1    appreciated  1  15334    2  191998
-2        certain  7  15334  120  191998
-3      measuring  1  15334    8  191998
-4   particularly  2  15334   47  191998
-5        arrived  2  15334    5  191998
-```
+  id
+  1    appreciated  1  15334    2  191998
+  2        certain  7  15334  120  191998
+  3      measuring  1  15334    8  191998
+  4   particularly  2  15334   47  191998
+  5        arrived  2  15334    5  191998
+  ```
+  where `f=O11`, `f1=O11+O12`, `f2=O11+O21`, `N=O11+O12+O21+O22`.
 
-Combinations of both are possible, but you should make sure to include four independent values, and that all of the following equations hold:
-
-- f = O11
-- f1 = O11 + O12
-- f2 = O11 + O21
-- N = O11 + O12 + O21 + O22
+- corpus frequencies (“keyword-friendly”):
+  ```python3
+  >>> df
+              item  f1     N1   f2      N2
+  id
+  1    appreciated   1  15334    1  176664
+  2        certain   7  15334  113  176664
+  3      measuring   1  15334    7  176664
+  4   particularly   2  15334   45  176664
+  5        arrived   2  15334    3  176664
+  ```
+  where `f1=O11`, `f2=O21`, `N1=O11+O12`, `N2=O21+O22`.
 
 ## Frequencies
 Given a dataframe as specified above, you can calculate expected frequencies via
 
 ```python3
 >>> import association_measures.frequencies as fq
->>> df_exp = fq.expected_frequencies(df)
->>> df_exp.head()
+>>> fq.expected_frequencies(df)
          E11           E12         E21            E22
 1   0.159731  15333.840269    1.840269  176662.159731
 2   9.583850  15324.416150  110.416150  176553.583850
@@ -80,8 +90,7 @@ The `observed_frequency` method will convert to contingency notation:
 
 ```python3
 >>> import association_measures.frequencies as fq
->>> df_obs = fq.observed_frequencies(df)
->>> df_obs.head()
+>>> fq.observed_frequencies(df)
     O11    O12  O21     O22
 id
 1     1  15333    1  176663
@@ -94,7 +103,7 @@ id
 Note that all methods return dataframes that are indexed the same way the input dataframe is indexed:
 
 ```python3
->>> df.head()
+>>> df
               f     f1   f2       N
 item
 appreciated   1  15334    2  191998
@@ -117,28 +126,33 @@ You can thus `join` the results directly to the input.
 
 ## Association Measures
 
-As of version 0.1.7, the following association measures are supported:
+The following association measures are currently implemented (v0.2.0):
 
 - asymptotic hypothesis tests:
   - z-score (`z_score`)
   - t-score (`t_score`)
+    - parameter: `disc`
   - log-likelihood (`log_likelihood`)
+    - parameter: `signed`
   - simple-ll (`simple_ll`)
+    - parameter: `signed`
 - point estimates of association strength:
   - log-ratio (`log_ratio`)
+    - parameter: `disc`
   - Dice coefficient (`dice`)
 - information theory:
   - mutual information (`mutual_information`)
+      - parameter: `disc`
   - local MI (`local_mutual_information`)
-- conservative estimates:
+- conservative estimates
   - conservative log-ratio (`conservative_log_ratio`)
+    - parameters: `disc`, `alpha`, `correct`, `one_sided`
 
 You can either calculate specific measures:
 
 ```python3
 >>> import association_measures.measures as am
->>> df_am = am.calculate_measures(df, measures=['log_likelihood', 'log_ratio'])
->>> df_am.head()
+>>> am.calculate_measures(df, measures=['log_likelihood', 'log_ratio'])
     log_likelihood  log_ratio
 1         2.448757   3.526202
 2        -0.829802  -0.486622
@@ -150,8 +164,7 @@ You can either calculate specific measures:
 or calculate all available measures:
 
 ```python3
->>> df = am.calculate_measures(df)
->>> df_am.head()
+>>> am.calculate_measures(df)
                z_score   t_score  log_likelihood  simple_ll      dice  log_ratio  mutual_information  local_mutual_information  conservative_log_ratio
 item
 appreciated   2.102442  0.840269        2.448757   1.987992  0.000130   3.526202            0.796611                  0.796611                     0.0
@@ -159,6 +172,50 @@ certain      -0.834636 -0.976603       -0.829802  -0.769331  0.000906  -0.486622
 measuring     0.451726  0.361077        0.191806   0.173788  0.000130   0.718847            0.194551                  0.194551                     0.0
 particularly -0.905150 -1.240035       -1.059386  -0.988997  0.000260  -0.965651           -0.273427                 -0.546853                     0.0
 arrived       2.533018  1.131847        3.879126   3.243141  0.000261   2.941240            0.699701                  1.399402                     0.0
+```
+
+**New in version 0.2.0:** `score()` is a more versatile interface, which allows constant integer counts to be given as parameters.  This is reasonable for the following notations:
+
+- frequency signature: integers `f1` and `N` (DataFrame contains columns `f` and `f2`)
+  ```python3
+  >>> df
+                f   f2
+  item
+  appreciated   1    2
+  certain       7  120
+  measuring     1    8
+  particularly  2   47
+  arrived       2    5
+  >>> am.score(df, f1=15334, N=191998, measures=['log_likelihood'])
+  ```
+
+- corpus frequencies: integers `N1` and `N2` (DataFrame contains columns `f1` and `f2`)
+  ```python3
+  >>> df
+                f1   f2
+  item
+  appreciated    1    1
+  certain        7  113
+  measuring      1    7
+  particularly   2   45
+  arrived        2    3
+  >>> am.score(df, N1=15334, N2=176664, measures=['log_likelihood'])
+  ```
+  
+Note that `score()` also returns absolute frequencies and instances per million by default:
+```python3
+              O11    O12  O21     O22       E11           E12         E21            E22  log_likelihood         ipm  ipm_reference  ipm_expected
+item
+appreciated     1  15333    1  176663  0.159731  15333.840269    1.840269  176662.159731        2.448757   65.214556       5.660463     10.416775
+certain         7  15327  113  176551  9.583850  15324.416150  110.416150  176553.583850       -0.829802  456.501891     639.632296    625.006510
+measuring       1  15333    7  176657  0.638923  15333.361077    7.361077  176656.638923        0.191806   65.214556      39.623240     41.667101
+particularly    2  15332   45  176619  3.753675  15330.246325   43.246325  176620.753675       -1.059386  130.429112     254.720826    244.794217
+arrived         2  15332    3  176661  0.399327  15333.600673    4.600673  176659.399327        3.879126  130.429112      16.981388     26.041938
+```
+
+Some association measures have parameters (see above). You can pass these parameters as keywords to `score` (or `calculate_measures`), e.g.:
+```python3
+>>> am.score(df, measures=['conservative_log_ratio'], disc=1, alpha=.05)
 ```
 
 # Development

--- a/association_measures/version.py
+++ b/association_measures/version.py
@@ -2,5 +2,5 @@
 Association measures are mathematical formulae that interpret cooccurrence frequency data.
 """
 
-VERSION = (0, 1, 7)
+VERSION = (0, 2, 0)
 __version__ = '.'.join(map(str, VERSION))

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from distutils.extension import Extension
 
 # Package meta-data.
 NAME = 'association-measures'
-DESCRIPTION = 'Corpus association measures for Python pandas'
+DESCRIPTION = 'Statistical association measures for Python pandas'
 URL = 'https://github.com/fau-klue/pandas-association-measures'
 EMAIL = 'markus@martialblog.de'
 AUTHOR = 'Markus Opolka'

--- a/tests/test_measures.py
+++ b/tests/test_measures.py
@@ -145,7 +145,8 @@ def test_t_score_invalid(invalid_dataframe):
 @pytest.mark.zero
 def test_t_score_zero(zero_dataframe):
     df = zero_dataframe
-    df_ams = am.calculate_measures(df, ['t_score'])
+    df_ams = am.calculate_measures(df, ['t_score'], freq=True, disc=.5)
+    print(df_ams.loc['der'])
     df_ams['t_score'][0] == 15.532438056926377
 
 
@@ -398,3 +399,46 @@ def test_measures_log_ratio_gold(log_ratio_dataframe):
                      ('clr', 'conservative_log_ratio')]:
 
         assert(round(df[r], 3).equals(round(df[assoc], 3)))
+
+
+#################
+# SCORE WRAPPER #
+#################
+@pytest.mark.score
+def test_score_notation(ucs_dataframe):
+
+    # frequency signature notation in dataframe:
+    df1 = am.score(ucs_dataframe)
+
+    # frequency signature notation with int parameters:
+    f1 = int(ucs_dataframe['f1'].iloc[0])
+    N = int(ucs_dataframe['N'].iloc[0])
+    df2 = am.score(ucs_dataframe[['f', 'f2']], f1, N)
+
+    # corpus frequency notation in dataframe:
+    tmp = ucs_dataframe[['f', 'f1']].rename({'f': 'f1', 'f1': 'N1'}, axis=1)
+    tmp['N2'] = ucs_dataframe['N'] - ucs_dataframe['f1']
+    tmp['f2'] = ucs_dataframe['f2'] - ucs_dataframe['f']
+    df3 = am.score(tmp)
+
+    # corpus frequency notation with int parameters:
+    N1 = int(tmp['N1'].iloc[0])
+    N2 = int(tmp['N2'].iloc[0])
+    df4 = am.score(tmp[['f1', 'f2']], N1=N1, N2=N2)
+
+    assert df1.equals(df2)
+    assert df2.equals(df3)
+    assert df3.equals(df4)
+
+
+@pytest.mark.score
+def test_score_invalid(ucs_dataframe):
+
+    with pytest.raises(ValueError):
+        am.score(ucs_dataframe, f1=1, N1=1)
+
+    with pytest.raises(ValueError):
+        am.score(ucs_dataframe, N2=1)
+
+    with pytest.raises(ValueError):
+        am.score(ucs_dataframe, f1=1, N2=1)

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -5,23 +5,31 @@ from pandas import read_csv
 
 def test_input():
 
+    # frequency signature notation
     df = read_csv("tests/ucs-gold-100.ds", comment='#', index_col=0,
                   sep="\t", quoting=3, keep_default_na=False)
-
     df.rename({'l2': 'item'}, axis=1, inplace=True)
-
     df = df[['item', 'f', 'f1', 'f2', 'N']]
-    print(df[['item', 'f', 'f1', 'f2', 'N']].head())
+    df.index.name = 'id'
+    print()
+    print(df.head())
 
+    # keywords
+    tmp = df[['item', 'f', 'f1']].rename({'f': 'f1', 'f1': 'N1'}, axis=1)
+    tmp['f2'] = df['f2'] - df['f']
+    tmp['N2'] = df['N'] - df['f1']
+    print(tmp.head())
+
+    # contingency notation
     obs = fq.observed_frequencies(df)
     print()
     print(obs[['O11', 'O12', 'O21', 'O22']].head())
 
+    # expected frequencies
     exp = fq.expected_frequencies(df)
     print()
     print(exp[['E11', 'E12', 'E21', 'E22']].head())
 
-    df = df.set_index('item')
     print()
     print(df.head())
     obs = fq.observed_frequencies(df)
@@ -47,3 +55,40 @@ def test_ams():
     df = df.set_index('item')
     df_ams = am.calculate_measures(df)
     print(df_ams.head())
+
+
+def test_score():
+
+    df = read_csv("tests/ucs-gold-100.ds", comment='#', index_col=0,
+                  sep="\t", quoting=3, keep_default_na=False)
+    df.rename({'l2': 'item'}, axis=1, inplace=True)
+
+    ucs_dataframe = df[['item', 'f', 'f1', 'f2', 'N']].set_index('item')
+
+    # frequency signature notation with int parameters:
+    f1 = int(ucs_dataframe['f1'].iloc[0])
+    N = int(ucs_dataframe['N'].iloc[0])
+    print(ucs_dataframe[['f', 'f2']].head())
+    df_sig = am.score(ucs_dataframe[['f', 'f2']], f1, N, measures=['log_likelihood'])
+    print("f1: ", f1)
+    print("N: ", N)
+    print(df_sig.head())
+
+    # corpus frequency notation with int parameters:
+    tmp = ucs_dataframe[['f', 'f1']].rename({'f': 'f1', 'f1': 'N1'}, axis=1)
+    tmp['N2'] = ucs_dataframe['N'] - ucs_dataframe['f1']
+    tmp['f2'] = ucs_dataframe['f2'] - ucs_dataframe['f']
+    N1 = int(tmp['N1'].iloc[0])
+    N2 = int(tmp['N2'].iloc[0])
+    print(tmp[['f1', 'f2']].head())
+    print("N1: ", N1)
+    print("N2: ", N2)
+    df_cor = am.score(tmp[['f1', 'f2']], N1=N1, N2=N2, measures=['log_likelihood'])
+    print(df_cor.head())
+
+    # parameters
+    df_cor = am.score(tmp[['f1', 'f2']], N1=N1, N2=N2, measures=['conservative_log_ratio'], freq=False, alpha=.01)
+    print(df_cor.head())
+
+    df_cor = am.score(tmp[['f1', 'f2']], N1=N1, N2=N2, measures=['conservative_log_ratio'], freq=False, alpha=1)
+    print(df_cor.head())


### PR DESCRIPTION
- new possible input: "keyword-friendly" corpus frequencies notation (f1, N1, f2, N2)
- new `score` wrapper also allows constant integer counts (N1, N2 for keyword notation; f1, N for frequency signatures) to be given as parameters
- keyword arguments are now passed from `calculate_measures()` (and `score()`) to underlying measures