### PR TITLE
Changes for Python 3.12

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,14 +4,15 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pytest = "==7.0.1"
-pylint = "==2.13.9"
-pytest-cov = "==3.0.0"
-twine = "==3.7.1"
+pytest = "==7.4.0"
+pylint = "==2.17.5"
+pytest-cov = "==4.1.0"
+twine = "==4.0.2"
 setuptools = "==68.0.0"
 cython = "==3.0.0"
 
 [packages]
-wheel = ">=0.37.1"
-pandas = ">=1.1.5"
+wheel = ">=0.41.1,<0.42"
+pandas = ">=1.3.5,<2.0"
+numpy = "<2.0.0"
 scipy = ">=1.5.4"

--- a/Pipfile
+++ b/Pipfile
@@ -8,8 +8,8 @@ pytest = "==7.0.1"
 pylint = "==2.13.9"
 pytest-cov = "==3.0.0"
 twine = "==3.7.1"
-setuptools = "==59.6.0"
-cython = "==0.29.30"
+setuptools = "==68.0.0"
+cython = "==3.0.0"
 
 [packages]
 wheel = ">=0.37.1"

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,7 @@
 
 import os
 import sys
-from setuptools import find_packages, Command
-from distutils.core import setup
-from distutils.extension import Extension
+from setuptools import find_packages, setup, Command, Extension
 
 # Package meta-data.
 NAME = 'association-measures'


### PR DESCRIPTION
Updated dependencies and changed setup.py to account for the deprecation of distutils in Python 3.12.

The dependencies in Pipfile have been changed to match the versions used by the current version of cwb-ccc.